### PR TITLE
Disabled IMU setYawAxis() call during simulation.

### DIFF
--- a/Mr_Steeltastic/simgui-window.json
+++ b/Mr_Steeltastic/simgui-window.json
@@ -23,7 +23,7 @@
     "###Joysticks": {
       "Collapsed": "0",
       "Pos": "375,697",
-      "Size": "976,278"
+      "Size": "976,82"
     },
     "###NetworkTables": {
       "Collapsed": "0",

--- a/Mr_Steeltastic/simgui.json
+++ b/Mr_Steeltastic/simgui.json
@@ -30,6 +30,9 @@
         "header": {
           "open": true
         }
+      },
+      "window": {
+        "visible": false
       }
     }
   },

--- a/Mr_Steeltastic/subsystems/drivetrain.py
+++ b/Mr_Steeltastic/subsystems/drivetrain.py
@@ -88,7 +88,10 @@ class Drivetrain(commands2.SubsystemBase):
         # Gyroscope to keep track of robot pitch
         self.gyro = wpilib.ADIS16470_IMU()
         self.gyro.CalibrationTime(2)
-        self.gyro.setYawAxis(self.gyro.IMUAxis.kX)
+
+        # Calling setYawAxis() during a simulation crashes the program
+        if wpilib.RobotBase.isReal():
+            self.gyro.setYawAxis(wpilib.ADIS16470_IMU.IMUAxis.kX)
 
         self.onChargeStation = False
         self.offChargeStation = False


### PR DESCRIPTION
This is quick fix to prevent simulation of robot.py from crashing during start up.